### PR TITLE
Fix warning: replace readall with readstring

### DIFF
--- a/src/github.jl
+++ b/src/github.jl
@@ -36,7 +36,7 @@ function curl(url::AbstractString, opts::Cmd=``)
             header[k] = v
             continue
         end
-        wait(proc); return status, header, readall(out)
+        wait(proc); return status, header, readstring(out)
     end
     throw(PkgError("strangely formatted HTTP response"))
 end

--- a/src/license.jl
+++ b/src/license.jl
@@ -9,7 +9,7 @@ const LICENSES = Dict(
 "Read license text from specified file and location"
 function readlicense(lic::AbstractString,
                      dir::AbstractString=normpath(dirname(@__FILE__), "..", "res", "licenses"))
-    return open(readall, joinpath(dir, lic))
+    return open(readstring, joinpath(dir, lic))
 end
 
 """


### PR DESCRIPTION
Fix warning: replace readall with readstring

`WARNING: readall is deprecated, use readstring instead.`

`readstring` is not defined in Julia v0.4 .

