### PR TITLE
Fixed tag url & deprecations 

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5-
 JSON
+URIParser

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5-
 JSON
 URIParser
+Compat

--- a/src/PkgDev.jl
+++ b/src/PkgDev.jl
@@ -1,7 +1,10 @@
 module PkgDev
 
+using Compat
+
 export Entry, Generate, GitHub
 
+include("utils.jl")
 include("github.jl")
 include("entry.jl")
 include("license.jl")

--- a/src/entry.jl
+++ b/src/entry.jl
@@ -7,6 +7,7 @@ importall Base.LibGit2
 using Base.Pkg.Types
 import ..PkgDev
 import ..PkgDev.GitHub
+import URIParser
 
 
 function pull_request(dir::AbstractString; commit::AbstractString="", url::AbstractString="", branch::AbstractString="")
@@ -252,7 +253,11 @@ function tag(pkg::AbstractString, ver::Union{Symbol,VersionNumber}, force::Bool=
                 write_tag_metadata(repo, pkg, ver, commit, force)
                 if LibGit2.isdirty(repo)
                     info("Committing METADATA for $pkg")
-                    LibGit2.commit(repo, "Tag $pkg v$ver [$(readchomp(urlfile))]")
+                    # Convert repo url into proper http url
+                    repouri = URIParser.URI(readchomp(urlfile))
+                    repopath = splitext(repouri.path)[1] # remove git suffix
+                    repourl = URIParser.URI("https", repouri.host, repouri.port, repopath)
+                    LibGit2.commit(repo, "Tag $pkg v$ver [$repourl]")
                 else
                     info("No METADATA changes to commit")
                 end

--- a/src/entry.jl
+++ b/src/entry.jl
@@ -7,8 +7,6 @@ importall Base.LibGit2
 using Base.Pkg.Types
 import ..PkgDev
 import ..PkgDev.GitHub
-import URIParser
-
 
 function pull_request(dir::AbstractString; commit::AbstractString="", url::AbstractString="", branch::AbstractString="")
     with(GitRepo, dir) do repo
@@ -254,9 +252,7 @@ function tag(pkg::AbstractString, ver::Union{Symbol,VersionNumber}, force::Bool=
                 if LibGit2.isdirty(repo)
                     info("Committing METADATA for $pkg")
                     # Convert repo url into proper http url
-                    repouri = URIParser.URI(readchomp(urlfile))
-                    repopath = splitext(repouri.path)[1] # remove git suffix
-                    repourl = URIParser.URI("https", repouri.host, repouri.port, repopath)
+                    repourl = getrepohttpurl(readchomp(urlfile))
                     LibGit2.commit(repo, "Tag $pkg v$ver [$repourl]")
                 else
                     info("No METADATA changes to commit")

--- a/src/github.jl
+++ b/src/github.jl
@@ -2,6 +2,7 @@ module GitHub
 
 import Main, Base.Pkg.PkgError
 import JSON
+using Compat
 
 const AUTH_NOTE = "Julia Package Manager"
 const AUTH_DATA = Dict{Any,Any}(

--- a/src/github.jl
+++ b/src/github.jl
@@ -36,7 +36,7 @@ function curl(url::AbstractString, opts::Cmd=``)
             header[k] = v
             continue
         end
-        wait(proc); return status, header, readall(out)
+        wait(proc); return status, header, readstring(out)
     end
     throw(PkgError("strangely formatted HTTP response"))
 end

--- a/src/license.jl
+++ b/src/license.jl
@@ -9,7 +9,7 @@ const LICENSES = Dict(
 "Read license text from specified file and location"
 function readlicense(lic::AbstractString,
                      dir::AbstractString=normpath(dirname(@__FILE__), "..", "res", "licenses"))
-    return open(readall, joinpath(dir, lic))
+    return open(readstring, joinpath(dir, lic))
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,8 @@
+import URIParser
+
+function getrepohttpurl(reporemoteurl::AbstractString)
+    repouri = URIParser.URI(reporemoteurl)
+    repopath = splitext(repouri.path)[1] # remove git suffix
+    repourl = URIParser.URI("https", repouri.host, repouri.port, repopath)
+    string(repourl)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using PkgDev
 using Base.Test
+using Compat
 import Base.Pkg.PkgError
 
 function temp_pkg_dir(fn::Function, remove_tmp_dir::Bool=true)
@@ -149,3 +150,9 @@ end"""
     end
 
 end
+
+@testset "Testing package utils" begin
+    @test PkgDev.getrepohttpurl("https://github.com/JuliaLang/PkgDev.jl.git") == "https://github.com/JuliaLang/PkgDev.jl"
+    @test PkgDev.getrepohttpurl("git://github.com/JuliaLang/PkgDev.jl.git")  == "https://github.com/JuliaLang/PkgDev.jl"
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ temp_pkg_dir() do pkgdir
     @testset "testing a package with test dependencies causes them to be installed for the duration of the test" begin
         PkgDev.generate("PackageWithTestDependencies", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
         @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
-        @test readall(Pkg.dir("PackageWithTestDependencies","REQUIRE")) == "julia $(PkgDev.Generate.versionfloor(VERSION))\n"
+        @test readstring(Pkg.dir("PackageWithTestDependencies","REQUIRE")) == "julia $(PkgDev.Generate.versionfloor(VERSION))\n"
 
         isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
         open(Pkg.dir("PackageWithTestDependencies","test","REQUIRE"),"w") do f
@@ -121,7 +121,7 @@ end"""
         @test !isempty(covfiles)
         for file in covfiles
             @test isfile(joinpath(covdir,file))
-            covstr = readall(joinpath(covdir,file))
+            covstr = readstring(joinpath(covdir,file))
             srclines = split(src, '\n')
             covlines = split(covstr, '\n')
             for i = 1:length(linetested)


### PR DESCRIPTION
fixed: #17
fixed: use `readstring` instead deprecated `readall`