### PR TITLE
WIP: create bundle for a package

### DIFF
--- a/src/PkgDev.jl
+++ b/src/PkgDev.jl
@@ -9,6 +9,7 @@ include("github.jl")
 include("entry.jl")
 include("license.jl")
 include("generate.jl")
+include("bundle.jl")
 
 const cd = Pkg.Dir.cd
 

--- a/src/bundle.jl
+++ b/src/bundle.jl
@@ -1,0 +1,36 @@
+"Search for all dependencies of specified package."
+function deps(pkg::AbstractString, pkgreqs, all_avail, res::Dict{AbstractString,VersionNumber})
+    for (dep, depvset) in pkgreqs
+        dep == "julia" && continue
+        haskey(res, dep) && continue
+        depvers = all_avail[dep]
+        supported = filter(vp->vp[2], map(v->(v,in(v,depvset)), sort(collect(keys(depvers)), rev=true)))
+        length(supported) == 0 && error("No supported versions of $dep")
+        depver = supported[1][1]
+        res[dep] = depver
+        deps(dep, all_avail[dep][depver].requires, all_avail, res)
+    end
+    return res
+end
+
+"""Bundle package with its dependencies
+
+Returns map of packages and their locations for the provided package and its dependencies
+"""
+function bundle(pkg::AbstractString="")
+    pkgdir = PkgDev.dir(pkg)
+    pkgreqfile = joinpath(pkgdir, "REQUIRE")
+    isfile(pkgreqfile) || error("Package $pkg does not have REQUIRE file")
+    pkgreqs = Pkg.Reqs.parse(pkgreqfile)
+    all_avail = Pkg.cd(Pkg.Read.available)
+
+    bundle = Dict{AbstractString,AbstractString}()
+    # println("Bundle for $pkg: $pkgdir")
+    bundle[pkg] = pkgdir
+    for (pkgdep, depver) in deps(pkg, pkgreqs, all_avail, Dict{AbstractString,VersionNumber}())
+        bundle[pkgdep] = PkgDev.dir(pkgdep)
+        # println("\t$pkgdep [$depver]: $(bundle[pkgdep])")
+    end
+    return bundle
+end
+


### PR DESCRIPTION
`bundle` command creates a folder/archive which would contain package and all its dependencies.

Possible command parameters:
- `pkg`: name of the bundled package (string)
- `output`: output folder or archive name
- `type`: folder/archive (symbol)
- `bindeps`: include binary dependencies (bool)

Ref: [julia/#15944](https://github.com/JuliaLang/julia/issues/15944)
