### PR TITLE
An idea: make the default mock test fail

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -188,7 +188,7 @@ function tests(pkg::AbstractString; force::Bool=false)
         using Base.Test
 
         # write your own tests here
-        @test 1 == 1
+        @test 1 == 2
         """)
     end
 end


### PR DESCRIPTION
The default test is going to be replaced, ideally. However, I've noticed packages sometimes getting released with this test left in there. PackageEvaluator reports this as passing, and possibly will continue to do so until something in the package fails to load at `using` time. I propose making it fail by default, which won't affect anyone doing the right thing at all, but will hopefully at least draw attention to this file for people who don't know about testing.

I'm not sure if this behaviour is depended on elsewhere, I mainly just wanted to float the idea.