### PR TITLE
Set permissions on the generated GitHub token

### DIFF
--- a/src/github.jl
+++ b/src/github.jl
@@ -83,6 +83,7 @@ Creating a personal access token for Julia Package Manager on GitHub.
 
     mkpath(dirname(tokfile))
     open(io->println(io,tok),tokfile,"w")
+    chmod(tokfile, 0o600)
     return tok
 end
 


### PR DESCRIPTION
Fixes #74.

When a GitHub token is generated, this sets the file's permissions to `600`. Unfortunately I have not a clue how to write a test for this, since running `token` on Travis would require somehow entering GitHub credentials. If someone can figure out that part, this could simply be tested with a combination of `uperm`, `gperm`, and `operm`.