### PR TITLE
change git paths to always be / separated

### DIFF
--- a/src/entry.jl
+++ b/src/entry.jl
@@ -128,9 +128,10 @@ function write_tag_metadata(repo::GitRepo, pkg::AbstractString, ver::VersionNumb
     end
     reqs = content !== nothing ? Reqs.read(split(content, '\n', keep=false)) : Reqs.Line[]
     cd(Pkg.dir("METADATA")) do
-        d = joinpath(pkg,"versions",string(ver))
+        # work around julia#18724 and PkgDev#28
+        d = join([pkg, "versions", string(ver)], '/')
         mkpath(d)
-        sha1file = joinpath(d,"sha1")
+        sha1file = join([d, "sha1"], '/')
         if !force && ispath(sha1file)
             current = readchomp(sha1file)
             current == commit ||
@@ -138,7 +139,7 @@ function write_tag_metadata(repo::GitRepo, pkg::AbstractString, ver::VersionNumb
         end
         open(io->println(io,commit), sha1file, "w")
         LibGit2.add!(repo, sha1file)
-        reqsfile = joinpath(d,"requires")
+        reqsfile = join([d, "requires"], '/')
         if isempty(reqs)
             ispath(reqsfile) && LibGit2.remove!(repo, reqsfile)
         else
@@ -169,7 +170,8 @@ function register(pkg::AbstractString, url::AbstractString)
         cd(metapath) do
             info("Registering $pkg at $url")
             mkdir(pkg)
-            path = joinpath(pkg,"url")
+            # work around julia#18724 and PkgDev#28
+            path = join([pkg, "url"], '/')
             open(io->println(io,url), path, "w")
             LibGit2.add!(repo, path)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,6 +132,12 @@ end"""
         end
     end
 
+    if haskey(ENV, "CI") && lowercase(ENV["CI"]) == "true"
+        info("setting git global configuration")
+        run(`git config --global user.name "Julia Test"`)
+        run(`git config --global user.email test@julialang.org`)
+        run(`git config --global github.user JuliaTest`)
+    end
 
     @testset "testing package tags" begin
         PkgDev.generate("PackageWithTags", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
@@ -170,12 +176,6 @@ end"""
     end
 
     @testset "testing package registration" begin
-        if haskey(ENV, "CI") && lowercase(ENV["CI"]) == "true"
-            info("setting git global configuration")
-            run(`git config --global user.name "Julia Test"`)
-            run(`git config --global user.email test@julialang.org`)
-            run(`git config --global github.user JuliaTest`)
-        end
         PkgDev.generate("GreatNewPackage", "MIT")
         PkgDev.register("GreatNewPackage")
         @test !isempty(readstring(joinpath(pkgdir, "METADATA", "GreatNewPackage", "url")))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,17 +135,27 @@ end"""
 
     @testset "testing package tags" begin
         PkgDev.generate("PackageWithTags", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
+        PkgDev.register("PackageWithTags")
         PkgDev.tag("PackageWithTags")
         PkgDev.tag("PackageWithTags")
 
         # check tags
-        repo = LibGit2.GitRepo(joinpath(pkgdir,"PackageWithTags"))
+        repo = LibGit2.GitRepo(joinpath(pkgdir, "PackageWithTags"))
+        meta_repo = LibGit2.GitRepo(joinpath(pkgdir, "METADATA"))
         try
             tags = LibGit2.tag_list(repo)
             @test ("v0.0.1" in tags) == true
             @test ("v0.0.2" in tags) == true
+            # test that those version files exist
+            @test ispath(joinpath(pkgdir, "METADATA", "PackageWithTags",
+                                  "versions", "0.0.1", "sha1")) == true
+            # check that we actually commited those files to METADATA
+            # (this test always succeeds for some reason -- we should be using
+            #  git_diff_index_to_workdir here)
+            @test LibGit2.isdirty(meta_repo) == false
         finally
             finalize(repo)
+            finalize(meta_repo)
         end
     end
 


### PR DESCRIPTION
fixes #28.

The `LibGit2.isdirty` test always succeeds for some reason, even though it should be calling [`git_diff_tree_to_workdir_with_index`](https://libgit2.github.com/libgit2/#HEAD/group/diff/git_diff_tree_to_workdir_with_index) which *should* be diffing the index against the working directory... Should maybe wrap [`git_diff_index_to_workdir`](https://libgit2.github.com/libgit2/#HEAD/group/diff/git_diff_index_to_workdir) or figure out why `isdirty` behaves the way it does.