### PR TITLE
Fixed reaction to temporary redirects in github API

### DIFF
--- a/src/github.jl
+++ b/src/github.jl
@@ -90,8 +90,8 @@ end
 function req(resource::AbstractString, data, opts::Cmd=``)
     url = "https://api.github.com/$resource"
     status, header, content = curl(url,data,`-u $(token()):x-oauth-basic $opts`)
-    if (status==302) | (status==307) # Temporary redirect
-        url=chomp(header["Location"])
+    if (status == 302) || (status == 307) # Temporary redirect
+        url = chomp(header["Location"])
         status, header, content = curl(url,data,`-u $(token()):x-oauth-basic $opts`)
     end
     response = JSON.parse(content)

--- a/src/github.jl
+++ b/src/github.jl
@@ -90,6 +90,10 @@ end
 function req(resource::AbstractString, data, opts::Cmd=``)
     url = "https://api.github.com/$resource"
     status, header, content = curl(url,data,`-u $(token()):x-oauth-basic $opts`)
+    if (status==302) | (status==307) # Temporary redirect
+        url=chomp(header["Location"])
+        status, header, content = curl(url,data,`-u $(token()):x-oauth-basic $opts`)
+    end
     response = JSON.parse(content)
     status, response
 end


### PR DESCRIPTION
According to https://developer.github.com/v3/#http-redirects One should react to Temporary Redirect replies from github.  This cures the error of the form

ERROR: forking JuliaStats/RCall.jl failed: Moved Permanently

that I get when I tried to use PkgDev.sumbit("RCall")
