### PR TITLE
Add tag_repo and upper-bound tools

### DIFF
--- a/src/PkgDev.jl
+++ b/src/PkgDev.jl
@@ -56,6 +56,19 @@ tag(pkg::AbstractString, ver::VersionNumber; force::Bool=false) = cd(Entry.tag,s
 tag(pkg::AbstractString, ver::VersionNumber, commit::AbstractString; force::Bool=false) =
     cd(Entry.tag,splitjl(pkg),ver,force,commit)
 
+"""
+    tag_repo(pkg, ver, [commit])
+
+Tag `commit` as version `ver` of package `pkg`, adding the tag only to
+the package git repository. `pkg` must be registered, and can be used
+to add missing tags to the package repository. By default, `commit` is
+chosen as the sha1 registered for version `ver`.
+"""
+tag_repo(pkg::AbstractString, ver::VersionNumber, commit::AbstractString; force::Bool=false) =
+    cd(Entry.tag_repo, pkg, ver, force, commit)
+tag_repo(pkg::AbstractString, ver::VersionNumber; force::Bool=false) =
+    tag_repo(pkg, ver, Pkg.Read.sha1(pkg, ver); force=force)
+
 submit(pkg::AbstractString) = cd(Entry.submit, splitjl(pkg))
 submit(pkg::AbstractString, commit::AbstractString) = cd(Entry.submit,splitjl(pkg),commit)
 
@@ -152,6 +165,55 @@ of a tagged release, and prints the number of commits that separate them. It can
 discover packages that may be due for tagging.
 """
 freeable(args...) = cd(Entry.freeable, args...)
+
+"""
+    PkgDev.add_upperbound(pkg, dependency, version)
+
+Assuming `pkg` depends on `dependency`, place an upper bound
+on the version number of `dependency` that can be used for `pkg`.
+This affects only the most recent version of `pkg` (see also
+[`propagate_upperbound`](@ref)).
+
+# Example
+
+Suppose `ColorTypes` has a REQUIRE file that looks like this:
+
+    julia 0.4
+    FixedPointNumbers 0.1.0
+
+and that this is registered with METADATA. Now suppose you are
+introducing breaking changes in version 0.3.0 of `FixedPointNumbers`.
+Using
+
+    PkgDev.add_upperbound("ColorTypes", "FixedPointNumbers", v"0.3.0")
+
+you modify both `ColorTypes/REQUIRE` and the latest
+`METADATA/ColorTypes/versions/x.x.x/requires` file to be
+
+    julia 0.4
+    FixedPointNumbers 0.1.0 0.3.0
+
+Both of these changes need to be committed and submitted, perhaps
+after [`PkgDev.propagate_upperbound`](@ref).
+"""
+add_upperbound(pkg::AbstractString, dependency::AbstractString, version::VersionNumber) =
+    Entry.add_upperbound(pkg, dependency, version)
+
+"""
+    PkgDev.propagate_upperbound(pkg, dependency)
+
+For package `pkg`, propagate the upper bound for package `dependency`
+(as specified in the latest tagged version of `pkg`) backwards through
+previous tags. Any previous lower upper bounds are retained. At the
+conclusion of the process, all previous versions of `pkg` depending on
+`dependency` will use an upper bound.
+
+The changes in METADATA must be committed and published separately.
+
+See also: [`PkgDev.add_upperbound`](@ref).
+"""
+propagate_upperbound(pkg::AbstractString, dependency::AbstractString) =
+    Entry.propagate_upperbound(pkg, dependency)
 
 function __init__()
     # Check if git configuration exists

--- a/src/entry.jl
+++ b/src/entry.jl
@@ -149,6 +149,13 @@ function write_tag_metadata(repo::GitRepo, pkg::AbstractString, ver::VersionNumb
     end
     return nothing
 end
+if isdefined(LibGit2, :GitHash)
+    write_tag_metadata(repo::GitRepo, pkg::AbstractString, ver::VersionNumber, commit::LibGit2.GitHash, force::Bool=false) =
+        write_tag_metadata(repo, pkg, ver, string(commit), force)
+else
+    write_tag_metadata(repo::GitRepo, pkg::AbstractString, ver::VersionNumber, commit::LibGit2.Oid, force::Bool=false) =
+        write_tag_metadata(repo, pkg, ver, string(commit), force)
+end
 
 function register(pkg::AbstractString, url::AbstractString)
     pkgdir = PkgDev.dir(pkg)
@@ -293,6 +300,27 @@ function tag(pkg::AbstractString, ver::Union{Symbol,VersionNumber}, force::Bool=
     return
 end
 
+function tag_repo(pkg::AbstractString, ver::VersionNumber, force::Bool, commitish::AbstractString)
+    pkgdir = PkgDev.dir(pkg)
+    ispath(pkgdir,".git") || throw(PkgError("$pkg is not a git repo"))
+    metapath = Pkg.dir("METADATA")
+    with(GitRepo,metapath) do repo
+        LibGit2.isdirty(repo, pkg) && throw(PkgError("METADATA/$pkg is dirty – commit or stash changes to tag"))
+    end
+    with(GitRepo, pkgdir) do repo
+        LibGit2.isdirty(repo) && throw(PkgError("$pkg is dirty – commit or stash changes to tag"))
+        commit = string(LibGit2.revparseid(repo, commitish))
+        urlfile = joinpath(metapath,pkg,"url")
+        isfile(urlfile) || error("$pkg is not registered")
+        # TODO: check that SHA1 isn't the same as another version
+        info("Tagging $pkg v$ver")
+        LibGit2.tag_create(repo, "v$ver", commit,
+                           msg=(!isrewritable(ver) ? "$pkg v$ver [$(commit[1:10])]" : ""),
+                           force=(force || isrewritable(ver)) )
+    end
+    return
+end
+
 function check_metadata(pkgs::Set{String} = Set{String}())
     avail = Pkg.cd(Read.available)
     deps, conflicts = Query.dependencies(avail)
@@ -352,6 +380,80 @@ function freeable(io::IO = STDOUT)
         end
     end
     freelist
+end
+
+function add_upperbound(pkg::AbstractString, dependency::AbstractString, version::VersionNumber)
+    # Determine the most recent version
+    latest = maximum(Pkg.available(pkg))
+    d = join(["METADATA", pkg, "versions", string(latest)], '/')
+
+    # Parse REQUIRE/requires and add the new upper bound
+    for (dirname, filename) in ((Pkg.dir(pkg), "REQUIRE"),
+                                (Pkg.dir(d), "requires"))
+        lines = cd(dirname) do
+            Pkg.Reqs.read(filename)
+        end
+        i = find_dependency_index(lines, dependency, pkg)
+        vs = getvs(lines[i])
+        if vs.upper < version
+            error("$pkg already has a tigher upper bound $(vs.upper) < $version")
+        end
+        vs.upper == typemax(VersionNumber) || vs.upper == version ||
+            warn("replacing upper bound $(vs.upper) with $version")
+        vs = Pkg.Types.VersionSet(vs.lower, version)
+        line = Pkg.Reqs.Requirement(lines[i].package, vs, lines[i].system)
+        lines[i] = line
+
+        # Write the updated files
+        cd(dirname) do
+            Pkg.Reqs.write(filename, lines)
+        end
+    end
+    nothing
+end
+
+function propagate_upperbound(pkg::AbstractString, dependency::AbstractString)
+    versions = Pkg.available(pkg)
+    latest = versions[end]
+    d = join(["METADATA", pkg, "versions", string(latest)], '/')
+    lines = cd(Pkg.dir(d)) do
+        Pkg.Reqs.read("requires")
+    end
+    i = find_dependency_index(lines, dependency, pkg)
+    vs = getvs(lines[i])
+
+    upper = vs.upper
+    for v in versions[end-1:-1:1]
+        d = join(["METADATA", pkg, "versions", string(v)], '/')
+        lines = cd(Pkg.dir(d)) do
+            Pkg.Reqs.read("requires")
+        end
+        idx = find(line->isa(line, Pkg.Reqs.Requirement) && line.package == dependency, lines)
+        isempty(idx) && continue
+        i = idx[1]
+        vs = getvs(lines[i])
+        if vs.upper > upper
+            vs = Pkg.Types.VersionSet(vs.lower, upper)
+            line = Pkg.Reqs.Requirement(lines[i].package, vs, lines[i].system)
+            lines[i] = line
+            cd(Pkg.dir(d)) do
+                Pkg.Reqs.write("requires", lines)
+            end
+        else
+            upper = vs.upper
+        end
+    end
+end
+
+function find_dependency_index(lines, dependency, pkg)
+    idx = find(line->isa(line, Pkg.Reqs.Requirement) && line.package == dependency, lines)
+    isempty(idx) && error("package $pkg doesn't depend on $dependency")
+    idx[1]
+end
+
+function getvs(line)
+    length(line.versions.intervals) == 1 || error("multiple bounds intervals are not supported, please edit file manually")
+    vs = line.versions.intervals[1]
 end
 
 end


### PR DESCRIPTION
Tools:

- `tag_repo`: for creating/reintroducing an appropriate tag corresponding to a registered version of the package. (Needed when fixing ancient history.)
- `add_upperbounds`: add an upper bound for the most recent release
- `propagate_upperbounds`: propagate an upper bound to previous releases