### PR TITLE
Avoid trailing space when generating license

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -156,7 +156,7 @@ function license(pkg::AbstractString,
         println(io, copyright(years,authors))
         lic=readlicense(license)
         for l in split(lic,['\n','\r'])
-            println(io, "> ", l)
+            println(io, ">", repeat(" ", length(l) > 0), l)
         end
     end
     !isempty(file) || info("License file exists, leaving unmodified; use `force=true` to overwrite")

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -156,7 +156,7 @@ function license(pkg::AbstractString,
         println(io, copyright(years,authors))
         lic=readlicense(license)
         for l in split(lic,['\n','\r'])
-            println(io, ">", repeat(" ", length(l) > 0), l)
+            println(io, ">", length(l) > 0 ? " " : "", l)
         end
     end
     !isempty(file) || info("License file exists, leaving unmodified; use `force=true` to overwrite")


### PR DESCRIPTION
Trailing spaces are not good-looking in some editors.