### PR TITLE
freeable: wrap revcount in try/catch

### DIFF
--- a/src/entry.jl
+++ b/src/entry.jl
@@ -325,6 +325,7 @@ function freeable(io::IO = STDOUT)
             ver, fix = status
             if fix
                 LibGit2.with(GitRepo(pkg)) do repo
+                    LibGit2.isdirty(repo) && return
                     head = string(LibGit2.head_oid(repo))
                     tag = latest_tag(pkg)
                     isnull(tag) && return

--- a/src/entry.jl
+++ b/src/entry.jl
@@ -330,7 +330,13 @@ function freeable(io::IO = STDOUT)
                     isnull(tag) && return
                     taggedsha = get(tag).sha1
                     if head != taggedsha
-                        vrs = LibGit2.revcount(repo, taggedsha, head)
+                        local vrs
+                        try
+                            vrs = LibGit2.revcount(repo, taggedsha, head)
+                        catch
+                            warn("skipping $pkg because the tagged commit $taggedsha was not found in the git revision history")
+                            return
+                        end
                         n = vrs[2] - vrs[1]
                         if firstprint
                             println(io, "Packages with a gap between HEAD and the most recent tag:")


### PR DESCRIPTION
If it can't identify the sha, better to skip the package than to fail.