### PR TITLE
Documented path kwarg for PkgDev.generate, use expanduser.

### DIFF
--- a/src/PkgDev.jl
+++ b/src/PkgDev.jl
@@ -77,22 +77,24 @@ publish(prbranch::AbstractString="") = Entry.publish(Pkg.Dir.getmetabranch(), pr
 doc"""
     generate(pkg,license)
 
-Generate a new package named `pkg` with one of these license keys:  `"MIT"`, `"BSD"`,
-`"ASL"`, `"MPL"`, `"GPL-2.0+"`, `"GPL-3.0+"`,  `"LGPL-2.1+"`, `"LGPL-3.0+"`. If you want to
-make a package with a  different license, you can edit it afterwards.
+Generate a new package named `pkg` with one of these license keys: `"MIT"`, `"BSD"`,
+`"ASL"`, `"MPL"`, `"GPL-2.0+"`, `"GPL-3.0+"`, `"LGPL-2.1+"`, `"LGPL-3.0+"`. If you want to
+make a package with a different license, you can edit it afterwards.
 
-Generate creates a git repo at `Pkg.dir(pkg)` for the package and  inside it `LICENSE.md`,
-`README.md`, `REQUIRE`, and the julia  entrypoint `$pkg/src/$pkg.jl`. Travis, AppVeyor CI
-configuration files `.travis.yml` and `appveyor.yml` with code coverage statistics using
-Coveralls or Codecov are created by default, but each can be disabled  individually by
-setting `travis`, `appveyor` or `coverage` to `false`.
+Generate creates a git repo `pkg` in `Pkg.dir()` (the default) or the specified `path`
+(which may contain a `~` for the user's home directory) for the package and inside it
+`LICENSE.md`, `README.md`, `REQUIRE`, and the julia entrypoint `$pkg/src/$pkg.jl`. Travis,
+AppVeyor CI configuration files `.travis.yml` and `appveyor.yml` with code coverage
+statistics using Coveralls or Codecov are created by default, but each can be disabled
+individually by setting `travis`, `appveyor` or `coverage` to `false`.
 """
 generate(pkg::AbstractString, license::AbstractString;
          force::Bool=false, authors::Union{AbstractString,Array} = [],
          config::Dict=Dict(), path::AbstractString = Pkg.Dir.path(),
          travis::Bool = true, appveyor::Bool = true, coverage::Bool = true) =
-    Generate.package(splitjl(pkg), license, force=force, authors=authors, config=config, path=path,
-                     travis=travis, appveyor=appveyor, coverage=coverage)
+             Generate.package(splitjl(pkg), license, force=force, authors=authors, config=config,
+                              path=expanduser(path), travis=travis, appveyor=appveyor,
+                              coverage=coverage)
 
 """
     config()


### PR DESCRIPTION
Rationale: paths for local repositories are frequently in user home
directories, and allowing `~` by default leads to terser syntax.