### PR TITLE
Remove unnecessary import

### DIFF
--- a/src/github.jl
+++ b/src/github.jl
@@ -1,6 +1,6 @@
 module GitHub
 
-import Main, Base.Pkg.PkgError
+import Base.Pkg.PkgError
 import JSON
 using Compat
 


### PR DESCRIPTION
In v0.7+, the `import Main` raises `Module Main not found in current path.` While it's likely that this is not intended in general, `Main` is no longer used in this package regardless.