### PR TITLE
Fix #101 again

### DIFF
--- a/src/entry.jl
+++ b/src/entry.jl
@@ -79,7 +79,7 @@ function publish(branch::AbstractString, prbranch::AbstractString="")
                     throw(Pkg.PkgError("$pkg v$ver SHA1 changed in METADATA – refusing to publish"))
                 end
             catch e
-                if !(e isa LibGit2.GitError)
+                if !(e isa LibGit2.GitError && e.code == LibGit2.Error.ENOTFOUND)
                     rethrow(e)
                 end
             end


### PR DESCRIPTION
#141 made some changes, however I forgot that `content` has different error handling behaviour than `cat`. This is a bit of a kludge, but hopefully should fix #101 again.