### PR TITLE
print TOML data in alphabetical order (with "julia" at the end)

### DIFF
--- a/src/tag.jl
+++ b/src/tag.jl
@@ -191,7 +191,7 @@ function tag_internal(
         pkg_toml_content["version"] = version_to_be_tagged
 
         open(pkg_project_toml_path, "w") do f
-            TOML.print(TOML_print_conversion, f, pkg_toml_content)
+            TOML.print(TOML_print_conversion, f, pkg_toml_content; sorted=true, by=key -> ifelse(key=="julia", "1", "0$key"))
         end
 
         project_as_it_should_be_tagged = Pkg.Types.read_project(pkg_project_toml_path)
@@ -208,7 +208,7 @@ function tag_internal(
         pkg_toml_content["version"] = next_version
 
         open(pkg_project_toml_path, "w") do f
-            TOML.print(TOML_print_conversion, f, pkg_toml_content)
+            TOML.print(TOML_print_conversion, f, pkg_toml_content; sorted=true, by=key -> ifelse(key=="julia", "1", "0$key"))
         end
 
         LibGit2.add!(pkg_repo, splitdir(pkg_project_toml_path)[2])


### PR DESCRIPTION
With this PR, when tagging a new version of the package, the entries of `[compat]`, `[deps]`, `[extras]`, etc, are printed in alphabetical order, except for `julia` which is is printed at the end of the list (following the Aqua style). 

Currently the entries are printed in random order, as the dict is unordered when read. 

This tries to address https://github.com/julia-vscode/julia-vscode/issues/3634

By at least following a style in the list (it does not preserve the list, which would require `TOML.parsefile` to read the data into an ordered dict, option which is currently unavailable).

Example of the output (I don't know how to actually test this in the package):

```julia
julia> prj = TOML.parsefile("./Project.toml");

julia> TOML.print(prj) # current behavior
name = "PkgDev"
uuid = "149e707d-584d-56d3-88ec-740c18e106ff"
version = "1.7.3-DEV"

[deps]
Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
PkgButlerEngine = "5c9c0fc8-7103-448b-bb0a-c427020e3b0b"
UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
DocumentFormat = "ffa9a821-9c82-50df-894e-fbcef3ed31cd"
RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

[extras]
Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

[compat]
GitHub = "5.1.1"
JSON = "0.21"
julia = "1.6"
FilePathsBase = "0.6, 0.7, 0.8, 0.9"
DocumentFormat = "4"
URIs = "1"
PkgButlerEngine = "1.2"
RegistryTools = "1"

[targets]
test = ["Test"]

julia> TOML.print(prj; sorted=true, by=key -> ifelse(key == "julia" , "1", "0$key")) # proposed in this PR
name = "PkgDev"
uuid = "149e707d-584d-56d3-88ec-740c18e106ff"
version = "1.7.3-DEV"

[compat]
DocumentFormat = "4"
FilePathsBase = "0.6, 0.7, 0.8, 0.9"
GitHub = "5.1.1"
JSON = "0.21"
PkgButlerEngine = "1.2"
RegistryTools = "1"
URIs = "1"
julia = "1.6"

[deps]
Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
DocumentFormat = "ffa9a821-9c82-50df-894e-fbcef3ed31cd"
FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
PkgButlerEngine = "5c9c0fc8-7103-448b-bb0a-c427020e3b0b"
RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"

[extras]
Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

[targets]
test = ["Test"]

julia>
```

